### PR TITLE
#7 added cli param -o (Order) to specify sorting. By default set to time:desc

### DIFF
--- a/horuz/commands/cmd_search.py
+++ b/horuz/commands/cmd_search.py
@@ -12,9 +12,10 @@ from horuz.utils.es import HoruzES
 @click.option('-q', '--query', required=True, help='Query to ElasticSeach')
 @click.option('-f', '--fields', help='Specify the fields you want.')
 @click.option('-s', '--size', default=100, type=click.IntRange(1, 10000), help='Specify the output size. Range 1-10000')
+@click.option('-o', '--order', default="time:desc", help='Specify the sorting of the query')
 @click.option('-oJ', is_flag=True, help="JSON Output")
 @pass_environment
-def cli(ctx, verbose, project, query, fields, size, oj):
+def cli(ctx, verbose, project, query, fields, size, order, oj):
     """
     Get data from ElasticSeach.
     """
@@ -24,7 +25,7 @@ def cli(ctx, verbose, project, query, fields, size, oj):
     if oj:
         # JSON Output
         data = beautify_query(
-            hes.query(term=query, size=size, fields=fields),
+            hes.query(term=query, size=size, order=order, fields=fields),
             fields,
             output="json")
         click.echo(data)
@@ -34,7 +35,7 @@ def cli(ctx, verbose, project, query, fields, size, oj):
         if not fields:
             fields = ["_id", "time", "session"]
         data = beautify_query(
-            hes.query(term=query, size=size, fields=fields),
+            hes.query(term=query, size=size, order=order, fields=fields),
             fields,
             output="interactive")
         click.echo_via_pager(tabulate(data, headers="keys"))

--- a/horuz/utils/es.py
+++ b/horuz/utils/es.py
@@ -127,7 +127,7 @@ class ElasticSearchAPI:
         except Exception as e:
             self.ctx.vlog("Mapping error {}".format(e))
 
-    def query(self, index, term, size=100, raw=False, fields=[]):
+    def query(self, index, term, size=100, order="time:desc", raw=False, fields=[]):
         """
         Search in Elasticsearch server
         Parameters
@@ -138,6 +138,8 @@ class ElasticSearchAPI:
             Search Query
         size : String
             Size query search
+        order : String
+            Sort by
         fields : List
             A list of fields of the source
         """
@@ -149,7 +151,7 @@ class ElasticSearchAPI:
                     return self.es.search(
                         index=index,
                         q=term,
-                        sort=["time:desc"],
+                        sort=[order],
                         size=size,
                         _source=fields)
                 except (RequestError, ConnectionError, ConnectionTimeout) as e:
@@ -353,14 +355,14 @@ class HoruzES:
                         data, session, filter_dups, remove_filter_dups)
         return
 
-    def query(self, term, size=100, raw=False, fields=[]):
+    def query(self, term, size=100, order="time:desc", raw=False, fields=[]):
         """
         Send Queries to ES
         """
         q = None
         self.ctx.vlog("Sending the query '{}' to ElasticSeach.".format(term))
         try:
-            q = self.es.query(self.domain, term, size, raw, fields)
+            q = self.es.query(self.domain, term, size, order, raw, fields)
         except Exception as e:
             self.ctx.log("Query connection failed: {}!".format(e))
             self.ctx.vlog("{}!".format(e))


### PR DESCRIPTION
I chose to name the param `order`, because `-s` for `sort` is already taken by `size`. So I saw `order` as natural for this case.